### PR TITLE
Fix double minting using the permit from token owner

### DIFF
--- a/contracts/src/Lightning.test.ts
+++ b/contracts/src/Lightning.test.ts
@@ -91,6 +91,7 @@ describe('Lightning', () => {
         Signature.create(tokenPrivateKey, [
           ...amount100.toFields(),
           ...userAddress.toFields(),
+          ...tokenApp.account.nonce.get().toFields(),
         ])
       );
     });

--- a/contracts/src/Token.test.ts
+++ b/contracts/src/Token.test.ts
@@ -74,6 +74,7 @@ describe('ExampleToken', () => {
     const mintSignature = Signature.create(zkAppPrivateKey, [
       ...amount100.toFields(),
       ...mintToAddress.toFields(),
+      ...zkApp.account.nonce.get().toFields(),
     ]);
 
     expect(zkApp.totalAmountInCirculation.get()).toEqual(UInt64.from(0));
@@ -85,10 +86,15 @@ describe('ExampleToken', () => {
     });
     await txn.prove();
     await txn.sign([deployerKey]).send();
+    const txn2 = await Mina.transaction(deployerAccount, () => {
+      zkApp.mint(mintToAddress, amount100, mintSignature);
+    });
+    await txn2.prove();
+    await txn2.sign([deployerKey]).send();
 
-    expect(zkApp.totalAmountInCirculation.get()).toEqual(amount100);
+    expect(zkApp.totalAmountInCirculation.get()).toEqual(amount100.mul(2));
 
-    expect(Mina.getBalance(mintToAddress, zkApp.token.id)).toEqual(amount100);
+    expect(Mina.getBalance(mintToAddress, zkApp.token.id)).toEqual(amount100.mul(2));
   });
 
   it('fails to send tokens when no balance', async () => {
@@ -114,6 +120,7 @@ describe('ExampleToken', () => {
     const mintSignature = Signature.create(zkAppPrivateKey, [
       ...amount100.toFields(),
       ...deployerAccount.toFields(),
+      ...zkApp.account.nonce.get().toFields(),
     ]);
 
     // successful send

--- a/contracts/src/Token.ts
+++ b/contracts/src/Token.ts
@@ -43,11 +43,13 @@ export class ExampleToken extends SmartContract {
     this.totalAmountInCirculation.assertEquals(totalAmountInCirculation);
 
     let newTotalAmountInCirculation = totalAmountInCirculation.add(amount);
+    let nonce = this.account.nonce.get();
+    this.account.nonce.assertEquals(nonce);
 
     adminSignature
       .verify(
         this.address,
-        amount.toFields().concat(receiverAddress.toFields())
+        amount.toFields().concat(...receiverAddress.toFields(), ...nonce.toFields())
       )
       .assertTrue();
 


### PR DESCRIPTION
Currently, it is possible to mint without any limitation using single permission from token owner. By using nonce to the signature, we can prevent it.